### PR TITLE
Doc: Add alternative to docker exec wait_all_done with wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ You will need to run the second `eval` command for every new terminal window.
 2. Wait until the grid starts properly before starting the tests _(Optional but recommended)_
 
         docker exec grid wait_all_done 30s
+        # Or if docker exec is not available (eg. circleci)
+        wget --retry-connrefused --no-check-certificate -T 30  http://localhost:4444/grid/console -O /dev/null
 
 After this, [Selenium][] will be up and ready to accept clients at `http://localhost:4444/wd/hub`. The grid's available browsers can be viewed by opening the console at `http://localhost:4444/grid/console`.
 If you are using Mac (OSX) or [Microsoft Windows](https://docs.docker.com/engine/installation/windows/) `localhost` won't work unless you are in Docker Beta (version >= 1.12) If you are using Docker version <= 1.11 please find out the correct IP through `docker-machine ip default`.


### PR DESCRIPTION
Add alternative to wait for the grid to be ready using `wget` instead of `docker exec` which is not available on `circleci`

You mention the `wait_all_done` a lot in the docs, should we mention this alternative only in the readme or on all places where you also mention the `wait_all_done`?