### PR TITLE
Update to Chrome 55.0.2883.75

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ For repository owners only:
 ### Chrome artifact
 Keep certain bins if chrome version changed for example:
 
-    cd ~/tmp_binaries && VER="54.0.2840.100" && NAME="google-chrome-stable_${VER}_amd64" && echo ${NAME}
+    cd ~/tmp_binaries && VER="55.0.2883.75" && NAME="google-chrome-stable_${VER}_amd64" && echo ${NAME}
     wget -nv --show-progress -O ${NAME}.deb "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
     md5sum ${NAME}.deb > ${NAME}.md5 && shasum ${NAME}.deb > ${NAME}.sha && cp ${NAME}.md5 ${NAME}.sha ~/dosel/binaries
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -592,7 +592,7 @@ RUN wget --no-verbose -O geckodriver.tar.gz \
 #===============
 # TODO: Use Google fingerprint to verify downloads
 #  https://www.google.de/linuxrepositories/
-ENV CHROME_VERSION_TRIGGER="54.0.2840.100" \
+ENV CHROME_VERSION_TRIGGER="55.0.2883.75" \
     CHROME_URL="https://dl.google.com/linux/direct" \
     CHROME_BASE_DEB_PATH="/home/seluser/chrome-deb/google-chrome" \
     GREP_ONLY_NUMS_VER="[0-9.]{2,20}"

--- a/capabilities.json
+++ b/capabilities.json
@@ -2,7 +2,7 @@
   "caps": [
     {
       "BROWSER_NAME": "chrome",
-      "VERSION": "54.0.2840.100",
+      "VERSION": "55.0.2883.75",
       "PLATFORM": "LINUX"
     },
     {


### PR DESCRIPTION
Problem: Old Chrome

Solution: Update to Chrome 55

Leo, there may be a lot of steps I'm missing. I simply looked for references to chrome 54 and updated them with hopes the build process would work it's magic. 

I'm hoping to learn all the steps needed here so that I could help with this in future releases.
