### PR TITLE
Make it possible to display Japanese/Chinese fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -327,6 +327,7 @@ RUN SHA="23925d017f8eccafb1be57c509a07df75490c83d" \
 # xfonts-scalable          ~2 MB
 # fonts-liberation         ~3 MB
 # fonts-ipafont-gothic     ~13 MB
+# fonts-wqy-zenhei         ~17 MB
 # ttf-ubuntu-font-family   ~5 MB
 #   Ubuntu Font Family, sans-serif typeface hinted for clarity
 # Removed packages:
@@ -344,6 +345,7 @@ RUN apt-get -qqy update \
     xfonts-scalable \
     fonts-liberation \
     fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
     ttf-ubuntu-font-family \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -326,10 +326,10 @@ RUN SHA="23925d017f8eccafb1be57c509a07df75490c83d" \
 # xfonts-cyrillic          ~2 MB
 # xfonts-scalable          ~2 MB
 # fonts-liberation         ~3 MB
+# fonts-ipafont-gothic     ~13 MB
 # ttf-ubuntu-font-family   ~5 MB
 #   Ubuntu Font Family, sans-serif typeface hinted for clarity
 # Removed packages:
-# fonts-ipafont-gothic     ~13 MB
 # xfonts-100dpi            ~6 MB
 # xfonts-75dpi             ~6 MB
 # Regarding fonts-liberation see:
@@ -343,6 +343,7 @@ RUN apt-get -qqy update \
     xfonts-cyrillic \
     xfonts-scalable \
     fonts-liberation \
+    fonts-ipafont-gothic \
     ttf-ubuntu-font-family \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -335,8 +335,8 @@ RUN SHA="23925d017f8eccafb1be57c509a07df75490c83d" \
 # xfonts-75dpi             ~6 MB
 # Regarding fonts-liberation see:
 #  https://github.com/SeleniumHQ/docker-selenium/issues/383#issuecomment-278367069
-# Layer size: small: 6.898 MB (with --no-install-recommends)
-# Layer size: small: 6.898 MB
+# Layer size: small: 36.28 MB (with --no-install-recommends)
+# Layer size: small: 36.28 MB
 RUN apt-get -qqy update \
   && apt-get -qqy --no-install-recommends install \
     libfontconfig \

--- a/capabilities.json
+++ b/capabilities.json
@@ -2,7 +2,7 @@
   "caps": [
     {
       "BROWSER_NAME": "chrome",
-      "VERSION": "58.0.3029.81",
+      "VERSION": "58.0.3029.96",
       "PLATFORM": "LINUX"
     },
     {

--- a/capabilities3.json
+++ b/capabilities3.json
@@ -2,7 +2,7 @@
   "caps": [
     {
       "BROWSER_NAME": "chrome",
-      "VERSION": "58.0.3029.81",
+      "VERSION": "58.0.3029.96",
       "PLATFORM": "LINUX"
     },
     {


### PR DESCRIPTION
Hi. I am trying to use docker-selenium and Zalenium in the company I am working for. I think Zalenium is one of the best solution to run E2E tests with Docker, so I really want to use it.

However, I found that docker-selenium and Zalenium cannot correctly display Japanese web pages because they do not have Japanese fonts.

In order to solve this problem, I added Japanese font and Chinese font in the Dockerfile. In this way, docker-selenium became possible to display Japanese and Chinese web pages. While the layer size becomes bigger, I think that this change is useful.

### Before

Here is the screenshot of the Japanese Facebook page at https://ja-jp.facebook.com/ that I took with the original elgalu/selenium Docker image.

![vid_chrome_25550_webm 3](https://cloud.githubusercontent.com/assets/1451339/25844303/f3965cf8-34e4-11e7-8502-568d97184e3f.png)

Chinese Facebook page at https://zh-cn.facebook.com/

![vid_chrome_25550_webm 4](https://cloud.githubusercontent.com/assets/1451339/25844297/ecb22804-34e4-11e7-9816-4de3ac5a0036.png)

### After

Here are the screenshots I took with the modified Docker image.

![vid_chrome_25550_webm](https://cloud.githubusercontent.com/assets/1451339/25844222/baa1795a-34e4-11e7-8e62-f18952c0fc57.png)

![vid_chrome_25550_webm 5](https://cloud.githubusercontent.com/assets/1451339/25844277/dae844f0-34e4-11e7-8445-f78794a92552.png)
