### PR TITLE
video-rec: use draw_mouse instead of nomouse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -758,6 +758,8 @@ ENV DEFAULT_SELENIUM_HUB_PORT="24444" \
 # FFMPEG_CODEC_ARGS
 #   Video size can be lowered down via re-encoding, see
 #    http://askubuntu.com/a/365221/134645
+# FFMPEG_DRAW_MOUSE
+#    Specify whether to draw the mouse pointer. Default: 1
 # VIDEO GRID CHROME FIREFOX RC_CHROME RC_FIREFOX
 #   true/false which services should start upon docker run
 # VIDEO_FILE_EXTENSION
@@ -871,6 +873,7 @@ ENV FIREFOX_VERSION="${FF_VER}" \
   FFMPEG_FRAME_RATE=10 \
   FFMPEG_CODEC_ARGS="-crf 0 -preset ultrafast -qp 0" \
   FFMPEG_FINAL_CRF=0 \
+  FFMPEG_DRAW_MOUSE=1 \
   VIDEO_TMP_FILE_EXTENSION="mkv" \
   VIDEO_FILE_EXTENSION="mp4" \
   MP4_INTERLEAVES_MEDIA_DATA_CHUNKS_SECS="500" \

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Relevant environment variables to customize it are:
     VIDEO_FILE_NAME="test"
     VIDEO_FILE_EXTENSION=mp4
     FFMPEG_CODEC_ARGS=""
+    FFMPEG_DRAW_MOUSE=1
 
 It is important to note that `ffmpeg` video recording takes an important amount of CPU usage, even more when a well compressed format like *mp4* is selected.
 

--- a/video-rec/bin/start-video-rec.sh
+++ b/video-rec/bin/start-video-rec.sh
@@ -37,7 +37,8 @@ sudo chown seluser:seluser "${tmp_video_path}"
 ffmpeg -f x11grab \
   -framerate ${FFMPEG_FRAME_RATE} \
   -video_size ${FFMPEG_FRAME_SIZE} \
-  -i "${DISPLAY}.0+0,0+nomouse" \
+  -i "${DISPLAY}.0+0,0" \
+  -draw_mouse ${FFMPEG_DRAW_MOUSE} \
   ${FFMPEG_CODEC_ARGS} \
   -segment_format_options movflags=+faststart \
   -y -an "${tmp_video_path}" 2>&1 &


### PR DESCRIPTION
Use draw_mouse=0 instead of +nomouse
according to:
https://www.ffmpeg.org/ffmpeg-devices.html#Options-19

otherwise the mouse pointer is still present with this version of ffmpeg