### PR TITLE
Quoting to keep parameters as they are

### DIFF
--- a/bin/notify
+++ b/bin/notify
@@ -2,4 +2,4 @@
 
 export DISPLAY=$(cat DISPLAY)
 
-exec notify-send $@
+exec notify-send "$@"


### PR DESCRIPTION
Just to avoid this:

```
seluser@20b25785da29:~$ notify Test "Test Failed" --icon=dialog-error
Invalid number of options.
```