### PR TITLE
Fix logs for video-recording

### DIFF
--- a/video-rec/bin/stop-video
+++ b/video-rec/bin/stop-video
@@ -39,6 +39,9 @@ else
   die "Were unable to stop video recording within '${WAIT_TIME_OUT_VIDEO_STOP}'"
 fi
 
+sed -i -e "s/\r/\n/g" ${LOGS_DIR}/video-rec-stderr.log || true
+sed -i -e "s/\r/\n/g" ${LOGS_DIR}/video-rec-stdout.log || true
+
 # Include videos log in the output
 log "-- DEBUG: video-rec-stdout.log ----"
 tail -n 40 ${LOGS_DIR}/video-rec-stdout.log || true


### PR DESCRIPTION
The log files "video-rec-stderr.log" and "video-rec-stdout.log" seem to contain "^M" characters (carriage-return).
The 'tail' command below doesn't take into account this character. It returns the complete output of the log files. Therefore it needs to be replaced into a proper newline.
This problem is not visible if executed in bash because each line will overwrite the previous line.