### PR TITLE
Fix for #297 - setting the cursor visibility

### DIFF
--- a/video-rec/bin/start-video-rec.sh
+++ b/video-rec/bin/start-video-rec.sh
@@ -49,8 +49,8 @@ fi
 # avconv or ffmpeg
 ffmpeg -f x11grab \
   -s ${FFMPEG_FRAME_SIZE} \
-  -i "${DISPLAY}.0" \
   -draw_mouse ${FFMPEG_DRAW_MOUSE} \
+  -i "${DISPLAY}.0" \
   ${FFMPEG_CODEC_ARGS} \
   -r ${FFMPEG_FRAME_RATE} \
   -y -an "${tmp_video_path}" 2>&1 &


### PR DESCRIPTION
`-draw_mouse` is an input option, so it has to go before the `-i` argument, otherwise it won't work.