### PR TITLE
Bump chromedriver version inline with chrome 79

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -509,7 +509,7 @@ USER seluser
 # Chrome webdriver
 #==================
 # How to get cpu arch dynamically: $(lscpu | grep Architecture | sed "s/^.*_//")
-ARG CHROME_DRIVER_VERSION="78.0.3904.105"
+ARG CHROME_DRIVER_VERSION="79.0.3945.36"
 ENV CHROME_DRIVER_BASE="chromedriver.storage.googleapis.com" \
     CPU_ARCH="64"
 ENV CHROME_DRIVER_FILE="chromedriver_linux${CPU_ARCH}.zip"


### PR DESCRIPTION
bump the chromedriver to 79 in-line with chrome version 79 to avoid mismatching